### PR TITLE
docs: sync from platform repo

### DIFF
--- a/docs/platform/flow-councils/operators/001-launch.md
+++ b/docs/platform/flow-councils/operators/001-launch.md
@@ -4,22 +4,46 @@ description: How to configure and deploy Flow Councils
 ---
 
 # Launch
-You can deploy a Flow Council yourself—no code required—from the [launchpad](https://flowstate.network/flow-councils/launch). Flow Councils are available on Arbitrum One, Base, Celo, and OP Mainnet.
 
-Each Flow Council is configured to distribute a single [Superfluid Super Token](https://docs.superfluid.org/docs/concepts/overview/super-tokens). Flow State natively supports many popular Super Tokens, but also allows deployers to set any [valid Super Token contract address](https://explorer.superfluid.org/arbitrum-one/supertokens) as the distribution currency. Once deployed, this token selection cannot be changed.
+You can deploy a Flow Council yourself—no code required—from the
+[launchpad](https://flowstate.network/flow-councils/launch). Flow Councils are
+available on Arbitrum One, Base, Celo, and OP Mainnet.
 
-On networks where the SuperApp Splitter factory is deployed (currently Celo), launching a council also deploys a **SuperApp Splitter**—the contract incoming funding streams route through. After launch, operators manage the round's funding from the [Funding](005-funding.md) page: sponsoring the funding stream, topping up the splitter, and scheduling or closing the round. Anyone can add to the funding anytime by [Growing the Pie](../participants/004-grow-the-pie.md).
+Each Flow Council is configured to distribute a single
+[Superfluid Super Token](https://docs.superfluid.org/docs/concepts/overview/super-tokens).
+Flow State natively supports many popular Super Tokens, but also allows
+deployers to set any
+[valid Super Token contract address](https://explorer.superfluid.org/arbitrum-one/supertokens)
+as the distribution currency. Once deployed, this token selection cannot be
+changed.
 
-By default, Flow Councils are open-ended. On councils with a splitter, operators can schedule a round end date from the [Funding](005-funding.md) page—once it passes, the round stops accepting incoming streams.
+Launching a council also deploys a **SuperApp Splitter**—the contract incoming
+funding streams route through. After launch, operators manage the round's
+funding from the [Funding](005-funding.md) page: sponsoring the funding stream,
+topping up the splitter, and scheduling or closing the round. Anyone can add to
+the funding anytime by [Growing the Pie](../participants/004-grow-the-pie.md).
 
-From the **Metadata** page, operators set the round's public name and description and choose whether it is **Listed** (surfaced on public discovery pages) or **Unlisted** (fully functional, reachable by direct link). New rounds default to Unlisted.
+By default, Flow Councils are open-ended. On councils with a splitter, operators
+can schedule a round end date from the [Funding](005-funding.md) page—once it
+passes, the round stops accepting incoming streams.
+
+From the **Metadata** page, operators set the round's public name and
+description and choose whether it is **Listed** (surfaced on public discovery
+pages) or **Unlisted** (fully functional, reachable by direct link). New rounds
+default to Unlisted.
 
 ## Permissions
 
-The deploying address is set as the Flow Council **Super Admin** by default. From the **Permissions** page, a Super Admin can grant any address one or more roles:
+The deploying address is set as the Flow Council **Super Admin** by default.
+From the **Permissions** page, a Super Admin can grant any address one or more
+roles:
 
-- **Super Admin** — full control, including managing other admins and every setting below.
+- **Super Admin** — full control, including managing other admins and every
+  setting below.
 - **Voter Review** — manages Council membership and voter groups.
-- **Recipient Review** — reviews applications and manages the recipients in the distribution pool.
+- **Recipient Review** — reviews applications and manages the recipients in the
+  distribution pool.
 
-Once a voting policy has been set and recipients have been added to the Flow Council, a Super Admin can remove themselves and all other admins to make the configuration immutable. See [Permissions](002-permissions.md) for details.
+Once a voting policy has been set and recipients have been added to the Flow
+Council, a Super Admin can remove themselves and all other admins to make the
+configuration immutable. See [Permissions](002-permissions.md) for details.

--- a/docs/platform/flow-councils/operators/005-funding.md
+++ b/docs/platform/flow-councils/operators/005-funding.md
@@ -1,40 +1,73 @@
 ---
 slug: /flow-councils/funding
-description: Sponsoring the funding stream, managing the SuperApp Splitter, and scheduling the round end
+description:
+  Sponsoring the funding stream, managing the SuperApp Splitter, and scheduling
+  the round end
 ---
 
 # Funding
 
-The **Funding** page of the launchpad is where operators manage the money flowing into a Flow Council. It appears for councils on networks where the SuperApp Splitter factory is deployed (currently **Celo**).
+The **Funding** page of the launchpad is where operators manage the money
+flowing into a Flow Council. Funding actions are available for councils with a
+SuperApp Splitter—every council launched going forward has one.
 
 ## The SuperApp Splitter
 
-On supported networks, launching a council also deploys its **SuperApp Splitter**—a stream-forwarding contract that sits between funders and the council's distribution pool. All incoming funding streams—the operator's sponsor stream and permissionless [Grow the Pie](../participants/004-grow-the-pie.md) streams—route through the splitter, which forwards them to the pool. That indirection is what gives operators control over the round's lifecycle:
+Launching a council also deploys its **SuperApp Splitter**—a stream-forwarding
+contract that sits between funders and the council's distribution pool. All
+incoming funding streams—the operator's sponsor stream and permissionless
+[Grow the Pie](../participants/004-grow-the-pie.md) streams—route through the
+splitter, which forwards them to the pool. That indirection is what gives
+operators control over the round's lifecycle:
 
-- **Close the round.** Admins can close all incoming streams on behalf of every funder—something that isn't possible with streams opened directly to the pool.
-- **Enforce an end date.** Once a scheduled end date passes, the splitter rejects new incoming streams.
-- **Collect the platform sustainability fee.** A small portion of the flow accrues in the contract until round close. The exact fee is shown on the Funding page.
+- **Close the round.** Admins can close all incoming streams on behalf of every
+  funder—something that isn't possible with streams opened directly to the pool.
+- **Enforce an end date.** Once a scheduled end date passes, the splitter
+  rejects new incoming streams.
+- **Collect the platform sustainability fee.** A small portion of the flow
+  accrues in the contract until round close. The exact fee is shown on the
+  Funding page.
 
-The splitter must always hold a small balance of the distribution token (at least four hours' worth at the current funding rate) to keep its outgoing stream solvent.
+The splitter must always hold a small balance of the distribution token (at
+least four hours' worth at the current funding rate) to keep its outgoing stream
+solvent.
 
-The page's information panel shows the splitter's address, the sustainability fee, the contract's current balance, the **implied max funding rate** that balance can support, and the round status (**Open**, **Open – Ends [date]**, or **Closed**).
+The page's information panel shows the splitter's address, the sustainability
+fee, the contract's current balance, the **implied max funding rate** that
+balance can support, and the round status (**Open**, **Open – Ends [date]**, or
+**Closed**).
 
 ## Sponsor stream
 
-Open the round's funding stream by entering a monthly flow rate. The checkout flow wraps underlying tokens into the Super Token if needed and tops up the splitter's buffer in the same batch transaction. The flow rate can be raised or lowered anytime as more funding becomes available or circumstances change.
+Open the round's funding stream by entering a monthly flow rate. The checkout
+flow wraps underlying tokens into the Super Token if needed and tops up the
+splitter's buffer in the same batch transaction. The flow rate can be raised or
+lowered anytime as more funding becomes available or circumstances change.
 
 ## Top up the splitter
 
-The splitter's balance caps the total funding rate it can sustain. The transfer section lets you make a one-time deposit to raise the implied max funding rate without opening or changing a stream.
+The splitter's balance caps the total funding rate it can sustain. The transfer
+section lets you make a one-time deposit to raise the implied max funding rate
+without opening or changing a stream.
 
 ## Round end date
 
-By default, rounds are open-ended. Here you can **schedule** an end date, **reschedule** it, or **remove** it. After the end date passes, the round shows as **Closed** and the splitter stops accepting new incoming streams; rescheduling to a future date or removing the date re-opens the round.
+By default, rounds are open-ended. Here you can **schedule** an end date,
+**reschedule** it, or **remove** it. After the end date passes, the round shows
+as **Closed** and the splitter stops accepting new incoming streams;
+rescheduling to a future date or removing the date re-opens the round.
 
 ## Close all streams
 
-The danger zone at the bottom of the page closes **every** incoming stream to the splitter in a single action—the definitive way to end a round. Closing is batched (up to 1,000 streams per transaction), so very large rounds may need more than one pass. You'll be asked to type a confirmation before the transaction is submitted.
+The danger zone at the bottom of the page closes **every** incoming stream to
+the splitter in a single action—the definitive way to end a round. Closing is
+batched (up to 1,000 streams per transaction), so very large rounds may need
+more than one pass. You'll be asked to type a confirmation before the
+transaction is submitted.
 
 :::note[Splitter roles]
-The splitter has its own onchain roles, separate from the [council roles](002-permissions.md). The deploying wallet is set as the splitter's admin and stream admin at launch; scheduling the round end and closing all streams require one of those roles.
+The splitter has its own onchain roles, separate from the
+[council roles](002-permissions.md). The deploying wallet is set as the
+splitter's admin and stream admin at launch; scheduling the round end and
+closing all streams require one of those roles.
 :::


### PR DESCRIPTION
Automated sync of `docs/**` from
[`flow-state-coop/platform`](https://github.com/flow-state-coop/platform).

**Source commit:** https://github.com/flow-state-coop/platform/commit/f848bd16d4f843fbdcfb848a4a96f7dba2c28bc9

> ⚠️ Do not edit `docs/**` in this repo directly — it is generated.
> Edit `docs/` in the **platform** repo; the `sync-docs` workflow mirrors it here.