### PR TITLE
docs: sync from platform repo

### DIFF
--- a/docs/platform/flow-councils/index.md
+++ b/docs/platform/flow-councils/index.md
@@ -19,7 +19,7 @@ Flow Councils are a great tool for grants programs, organizational budgeting, an
 
 ![Flow Council Architecture_2](https://github.com/user-attachments/assets/5e6e1d40-733f-40a7-8752-146d2f6867d6)
 
-You can launch a Flow Council yourself with the no-code [launchpad](https://flowstate.network/flow-councils/launch), or reach out to us on [Telegram](https://t.me/flowstatecoop) if you'd like a hand getting started.
+You can launch a Flow Council yourself with the no-code [launchpad](https://flowstate.network/flow-councils/launch), or reach out to us on [Telegram](https://t.me/+U6ZFRmOnFWo1ZGUx) if you'd like a hand getting started.
 
 The docs are split by role:
 

--- a/docs/platform/flow-guilds.md
+++ b/docs/platform/flow-guilds.md
@@ -26,5 +26,5 @@ Two ways to contribute, both from the guild page:
 If you're a recipient in the guild's [Flow Splitter](flow-splitters/index.md) but haven't connected your shares, the page prompts you to connect so your [Super Token balance](https://app.superfluid.finance/) reflects in real time.
 
 :::info[Guilds are curated]
-Flow Guild pages are set up in coordination with Flow State. If you'd like a guild page for your community, [reach out on Telegram](https://t.me/flowstatecoop).
+Flow Guild pages are set up in coordination with Flow State. If you'd like a guild page for your community, [reach out on Telegram](https://t.me/+U6ZFRmOnFWo1ZGUx).
 :::

--- a/docs/platform/flow-qf.md
+++ b/docs/platform/flow-qf.md
@@ -7,7 +7,7 @@ sidebar_position: 3
 # Flow QF
 
 :::tip[Want to run a round?]
-We've designed and run Flow QF rounds, and we're happy to set one up for your ecosystem or community. [Get in touch on Telegram](https://t.me/flowstatecoop) if you want to run a round.
+We've designed and run Flow QF rounds, and we're happy to set one up for your ecosystem or community. [Get in touch on Telegram](https://t.me/+U6ZFRmOnFWo1ZGUx) if you want to run a round.
 :::
 
 Flow QF (aka Streaming Quadratic Funding, or SQF) is a novel implementation of [quadratic funding (QF)](https://www.wtfisqf.com/?grant=&grant=&grant=&grant=&match=1000), the public goods funding mechanism [introduced by Vitalik Buterin, Zoe Hitzig, & Glen Weyl](https://arxiv.org/pdf/1809.06421) and popularized in web3 by [Gitcoin](https://www.gitcoin.co/).

--- a/docs/platform/flow-splitters/index.md
+++ b/docs/platform/flow-splitters/index.md
@@ -20,7 +20,7 @@ Settlement is passive and gasless–-meaning payouts don’t need to be periodic
 
 Flow Splitters make this powerful onchain primitive accessible through a no-code interface and tooling to encourage more dynamic, creative, and effective pool management.
 
-Streams are the ultimate form of programmable money. We want more teams, guilds, DAOs, and communities to be able to tap into their power. [Give us a shout if you have feedback or ideas](https://t.me/flowstatecoop).
+Streams are the ultimate form of programmable money. We want more teams, guilds, DAOs, and communities to be able to tap into their power. [Give us a shout if you have feedback or ideas](https://t.me/+U6ZFRmOnFWo1ZGUx).
 
 :::info[What is streaming money?]
 Check out the [Superfluid Docs](https://docs.superfluid.finance/docs/concepts/superfluid) to learn more about [streaming money](https://docs.superfluid.finance/docs/concepts/overview/money-streaming), [Super Tokens](https://docs.superfluid.finance/docs/concepts/overview/super-tokens), [distribution pools](https://docs.superfluid.finance/docs/concepts/overview/distributions), and other protocol foundations. 

--- a/docs/welcome.md
+++ b/docs/welcome.md
@@ -11,6 +11,6 @@ We believe that streams are the ultimate form of programmable money—real-time,
 
 We are structured as a Colorado Limited Cooperative. This means we are democratically governed and have unique opportunities to design incentive-aligned (onchain) profit distribution mechanisms across multiple stakeholder classes.
 
-For more info, dive into the rest of these docs and [join our community Telegram](https://t.me/flowstatecoop/).
+For more info, dive into the rest of these docs and [join our community Telegram](https://t.me/+U6ZFRmOnFWo1ZGUx).
 
 ![Stream Pill](https://github.com/user-attachments/assets/2626df26-eed5-4675-b0b9-597c04a18ecc)


### PR DESCRIPTION
Automated sync of `docs/**` from
[`flow-state-coop/platform`](https://github.com/flow-state-coop/platform).

**Source commit:** https://github.com/flow-state-coop/platform/commit/0909ec360567310d5837fc170a8a2e0f335278a3

> ⚠️ Do not edit `docs/**` in this repo directly — it is generated.
> Edit `docs/` in the **platform** repo; the `sync-docs` workflow mirrors it here.