### PR TITLE
docs: sync from platform repo

### DIFF
--- a/docs/platform/flow-qf.md
+++ b/docs/platform/flow-qf.md
@@ -6,8 +6,8 @@ sidebar_position: 3
 
 # Flow QF
 
-:::tip[Want to run a round?]
-We've designed and run Flow QF rounds, and we're happy to set one up for your ecosystem or community. [Get in touch on Telegram](https://t.me/+U6ZFRmOnFWo1ZGUx) if you want to run a round.
+:::tip[Want to run a Flow QF round?]
+Flow QF rounds aren't self-serve: we design and run them with you. [Get in touch on Telegram](https://t.me/+U6ZFRmOnFWo1ZGUx) or email [info@flowstate.network](mailto:info@flowstate.network) and we'll set one up for your ecosystem or community. More on [what that looks like](#run-a-flow-qf-round) below.
 :::
 
 Flow QF (aka Streaming Quadratic Funding, or SQF) is a novel implementation of [quadratic funding (QF)](https://www.wtfisqf.com/?grant=&grant=&grant=&grant=&match=1000), the public goods funding mechanism [introduced by Vitalik Buterin, Zoe Hitzig, & Glen Weyl](https://arxiv.org/pdf/1809.06421) and popularized in web3 by [Gitcoin](https://www.gitcoin.co/).
@@ -33,3 +33,17 @@ The periodic round structure also asks a lot of donors/voters. It’s difficult 
 Flow QF’s continuous model can also provide more funding predictability for grantees. Funds streamed through a Flow QF pool immediately hit the grantee’s account with incremental shifts in receipts.
 
 This velocity means amplified impact and efficiency with limited capital from funders. Take the [Geo Web](https://geoweb.network) protocol (where [Flow QF was invented](https://geoweb.land/governance)) for example. It generates ETH streams from its [PCO land market](https://docs.geoweb.network/concepts/partial-common-ownership/). Before Flow QF, these funds would idly accumulate in the treasury until being periodically dispersed. Now, the Geo Web’s ETH can immediately help grow the network (i.e., grow the ETH revenue the land market generates) and drive a public goods flywheel. This is how scrappy public goods can outcompete lavishly-funded behemoths.
+
+## Run a Flow QF round
+
+Unlike [Flow Councils](flow-councils/index.md) and [Flow Splitters](flow-splitters/index.md), Flow QF isn't a no-code launchpad. We run each round together with the funder, from design through wrap-up:
+
+- **Round design**: matching pool size and duration, network and token, eligibility criteria, and the matching parameters that fit your goals.
+- **Applications & review**: grantee onboarding, application collection, and review with your team.
+- **A round page**: where donors discover grantees and open their donation streams, with matching updating in real time.
+- **Donor & grantee support**: onboarding both sides of the round and keeping streams healthy while it runs.
+
+We've designed and run rounds like the [Geo Web](https://geoweb.land/governance)'s and the Octant Builder Accelerator. Tell us about your ecosystem, your budget, and when you'd like to start:
+
+- **Telegram**: [message us](https://t.me/+U6ZFRmOnFWo1ZGUx)
+- **Email**: [info@flowstate.network](mailto:info@flowstate.network)


### PR DESCRIPTION
Automated sync of `docs/**` from
[`flow-state-coop/platform`](https://github.com/flow-state-coop/platform).

**Source commit:** https://github.com/flow-state-coop/platform/commit/c26f235ac29a2dd7a664d0fd9827eb27e8842d8b

> ⚠️ Do not edit `docs/**` in this repo directly — it is generated.
> Edit `docs/` in the **platform** repo; the `sync-docs` workflow mirrors it here.